### PR TITLE
Fix tracking fields and progress strings

### DIFF
--- a/bunnyvideo/classes/output/renderer.php
+++ b/bunnyvideo/classes/output/renderer.php
@@ -13,9 +13,9 @@ class renderer extends \plugin_renderer_base {
         $playerid = 'bunnyvideo-player-' . $cm->id;
         $secureurl = \bunnyvideo_generate_signed_url($bunnyvideo->videopath);
 
-        // Use new database fields for tracking
-        $completionEnabled = !empty($bunnyvideo->completion_track);
-        $threshold = isset($bunnyvideo->track_threshold) ? (int)$bunnyvideo->track_threshold : 95;
+        // Use standard completion fields for tracking
+        $completionEnabled = !empty($bunnyvideo->completionvideo);
+        $threshold = isset($bunnyvideo->completionpercent) ? (int)$bunnyvideo->completionpercent : 80;
 
         $progress = [
             'watchtime' => 0,

--- a/bunnyvideo/lang/en/bunnyvideo.php
+++ b/bunnyvideo/lang/en/bunnyvideo.php
@@ -43,3 +43,11 @@ $string['defaultcompletionvideo_desc'] = 'If enabled, new Bunny Video activities
 
 $string['completionthreshold'] = 'Default completion percentage';
 $string['completionthreshold_desc'] = 'Default percentage of video watched required for completion, for new activities.';
+
+// Player strings
+$string['progress'] = 'Progress';
+$string['completed'] = 'Completed';
+$string['novideosupport'] = 'Your browser does not support HTML5 video.';
+
+// Misc
+$string['nobunnyvideos'] = 'No Bunny videos found';


### PR DESCRIPTION
## Summary
- fix renderer to use completionvideo and completionpercent fields
- add missing language strings for progress bar and other messages

## Testing
- `php -l bunnyvideo/classes/output/renderer.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ef88535483219612b9f24daccca2